### PR TITLE
Poprawa testów i formatowania w plikach UnitTest

### DIFF
--- a/BusinessLogicTest/BusinessBallUnitTest.cs
+++ b/BusinessLogicTest/BusinessBallUnitTest.cs
@@ -1,51 +1,56 @@
 ﻿namespace TP.ConcurrentProgramming.BusinessLogic.Test
 {
-  [TestClass]
-  public class BallUnitTest
-  {
-    [TestMethod]
-    public void MoveTestMethod()
+    [TestClass]
+    public class BallUnitTest
     {
-      DataBallFixture dataBallFixture = new DataBallFixture();
-      Ball newInstance = new(dataBallFixture);
-      int numberOfCallBackCalled = 0;
-      newInstance.NewPositionNotification += (sender, position) => { Assert.IsNotNull(sender); Assert.IsNotNull(position); numberOfCallBackCalled++; };
-      dataBallFixture.Move();
-      Assert.AreEqual<int>(1, numberOfCallBackCalled);
+        [TestMethod]
+        public void MoveTestMethod()
+        {
+            DataBallFixture dataBallFixture = new DataBallFixture();
+            Ball newInstance = new(dataBallFixture);
+            int numberOfCallBackCalled = 0;
+            newInstance.NewPositionNotification += (sender, position) => { Assert.IsNotNull(sender); Assert.IsNotNull(position); numberOfCallBackCalled++; };
+            dataBallFixture.Move();
+            Assert.AreEqual<int>(1, numberOfCallBackCalled);
+        }
+
+        #region testing instrumentation
+
+        private class DataBallFixture : Data.IBall
+        {
+            public event EventHandler<Data.IVector>? NewPositionNotification;
+            public Data.IVector Velocity { get; set; } = new VectorFixture(0, 0);
+            public double Diameter { get; } = 30.0;
+            public double Mass { get; } = 1.0;
+            public Data.IVector Position { get; } = new VectorFixture(0, 0);
+
+            public void UpdatePosition(Data.IVector newPosition)
+            {
+                
+            }
+
+            public void UpdateVelocity(Data.IVector newVelocity)
+            {
+                Velocity = newVelocity;
+            }
+
+            internal void Move()
+            {
+                NewPositionNotification?.Invoke(this, new VectorFixture(0.0, 0.0));
+            }
+        }
+
+        private class VectorFixture : Data.IVector
+        {
+            internal VectorFixture(double X, double Y)
+            {
+                x = X; y = Y;
+            }
+
+            public double x { get; init; }
+            public double y { get; init; }
+        }
+
+        #endregion testing instrumentation
     }
-
-    #region testing instrumentation
-
-    private class DataBallFixture : Data.IBall
-    {
-      public event EventHandler<Data.IVector>? NewPositionNotification;
-      public Data.IVector Velocity { get; set; } = new VectorFixture(0, 0);
-      public double Diameter { get; } = 30.0;
-      public double Mass { get; } = 1.0;
-      public Data.IVector Position { get; } = new VectorFixture(0, 0);
-
-      public void UpdateVelocity(Data.IVector newVelocity)
-      {
-        Velocity = newVelocity;
-      }
-
-      internal void Move()
-      {
-        NewPositionNotification?.Invoke(this, new VectorFixture(0.0, 0.0));
-      }
-    }
-
-    private class VectorFixture : Data.IVector
-    {
-      internal VectorFixture(double X, double Y)
-      {
-        x = X; y = Y;
-      }
-
-      public double x { get; init; }
-      public double y { get; init; }
-    }
-
-    #endregion testing instrumentation
-  }
 }

--- a/BusinessLogicTest/BusinessLogicUnitTest.cs
+++ b/BusinessLogicTest/BusinessLogicUnitTest.cs
@@ -2,118 +2,123 @@
 
 namespace TP.ConcurrentProgramming.BusinessLogic.Test
 {
-  [TestClass]
-  public class BusinessLogicImplementationUnitTest
-  {
-    [TestMethod]
-    public void ConstructorTestMethod()
+    [TestClass]
+    public class BusinessLogicImplementationUnitTest
     {
-      using (BusinessLogicImplementation newInstance = new(new DataLayerConstructorFixcure()))
-      {
-        bool newInstanceDisposed = true;
-        newInstance.CheckObjectDisposed(x => newInstanceDisposed = x);
-        Assert.IsFalse(newInstanceDisposed);
-      }
-    }
-
-    [TestMethod]
-    public void DisposeTestMethod()
-    {
-      DataLayerDisposeFixcure dataLayerFixcure = new();
-      BusinessLogicImplementation newInstance = new(dataLayerFixcure);
-      Assert.IsFalse(dataLayerFixcure.Disposed);
-      bool newInstanceDisposed = true;
-      newInstance.CheckObjectDisposed(x => newInstanceDisposed = x);
-      Assert.IsFalse(newInstanceDisposed);
-      newInstance.Dispose();
-      newInstance.CheckObjectDisposed(x => newInstanceDisposed = x);
-      Assert.IsTrue(newInstanceDisposed);
-      Assert.ThrowsException<ObjectDisposedException>(() => newInstance.Dispose());
-      Assert.ThrowsException<ObjectDisposedException>(() => newInstance.Start(0, (position, ball) => { }));
-      Assert.IsTrue(dataLayerFixcure.Disposed);
-    }
-
-    [TestMethod]
-    public void StartTestMethod()
-    {
-      DataLayerStartFixcure dataLayerFixcure = new();
-      using (BusinessLogicImplementation newInstance = new(dataLayerFixcure))
-      {
-        int called = 0;
-        int numberOfBalls2Create = 10;
-        newInstance.Start(
-          numberOfBalls2Create,
-          (startingPosition, ball) => { called++; Assert.IsNotNull(startingPosition); Assert.IsNotNull(ball); });
-        Assert.AreEqual<int>(1, called);
-        Assert.IsTrue(dataLayerFixcure.StartCalled);
-        Assert.AreEqual<int>(numberOfBalls2Create, dataLayerFixcure.NumberOfBallseCreated);
-      }
-    }
-
-    #region testing instrumentation
-
-    private class DataLayerConstructorFixcure : Data.DataAbstractAPI
-    {
-      public override void Dispose()
-      { }
-
-      public override void Start(int numberOfBalls, Action<IVector, Data.IBall> upperLayerHandler)
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    private class DataLayerDisposeFixcure : Data.DataAbstractAPI
-    {
-      internal bool Disposed = false;
-
-      public override void Dispose()
-      {
-        Disposed = true;
-      }
-
-      public override void Start(int numberOfBalls, Action<IVector, Data.IBall> upperLayerHandler)
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    private class DataLayerStartFixcure : Data.DataAbstractAPI
-    {
-      internal bool StartCalled = false;
-      internal int NumberOfBallseCreated = -1;
-
-      public override void Dispose()
-      { }
-
-      public override void Start(int numberOfBalls, Action<IVector, Data.IBall> upperLayerHandler)
-      {
-        StartCalled = true;
-        NumberOfBallseCreated = numberOfBalls;
-        upperLayerHandler(new DataVectorFixture(), new DataBallFixture());
-      }
-
-      private record DataVectorFixture : Data.IVector
-      {
-        public double x { get; init; }
-        public double y { get; init; }
-      }
-
-      private class DataBallFixture : Data.IBall
-      {
-        public event EventHandler<Data.IVector>? NewPositionNotification;
-        public Data.IVector Velocity { get; set; } = new DataVectorFixture();
-        public double Diameter { get; } = 30.0;
-        public double Mass { get; } = 1.0;
-        public Data.IVector Position { get; } = new DataVectorFixture();
-
-        public void UpdateVelocity(Data.IVector newVelocity)
+        [TestMethod]
+        public void ConstructorTestMethod()
         {
-          throw new NotImplementedException();
+            using (BusinessLogicImplementation newInstance = new(new DataLayerConstructorFixcure()))
+            {
+                bool newInstanceDisposed = true;
+                newInstance.CheckObjectDisposed(x => newInstanceDisposed = x);
+                Assert.IsFalse(newInstanceDisposed);
+            }
         }
-      }
-    }
 
-    #endregion testing instrumentation
-  }
+        [TestMethod]
+        public void DisposeTestMethod()
+        {
+            DataLayerDisposeFixcure dataLayerFixcure = new();
+            BusinessLogicImplementation newInstance = new(dataLayerFixcure);
+            Assert.IsFalse(dataLayerFixcure.Disposed);
+            bool newInstanceDisposed = true;
+            newInstance.CheckObjectDisposed(x => newInstanceDisposed = x);
+            Assert.IsFalse(newInstanceDisposed);
+            newInstance.Dispose();
+            newInstance.CheckObjectDisposed(x => newInstanceDisposed = x);
+            Assert.IsTrue(newInstanceDisposed);
+            Assert.ThrowsException<ObjectDisposedException>(() => newInstance.Dispose());
+            Assert.ThrowsException<ObjectDisposedException>(() => newInstance.Start(0, (position, ball) => { }));
+            Assert.IsTrue(dataLayerFixcure.Disposed);
+        }
+
+        [TestMethod]
+        public void StartTestMethod()
+        {
+            DataLayerStartFixcure dataLayerFixcure = new();
+            using (BusinessLogicImplementation newInstance = new(dataLayerFixcure))
+            {
+                int called = 0;
+                int numberOfBalls2Create = 10;
+                newInstance.Start(
+                  numberOfBalls2Create,
+                  (startingPosition, ball) => { called++; Assert.IsNotNull(startingPosition); Assert.IsNotNull(ball); });
+                Assert.AreEqual<int>(1, called);
+                Assert.IsTrue(dataLayerFixcure.StartCalled);
+                Assert.AreEqual<int>(numberOfBalls2Create, dataLayerFixcure.NumberOfBallseCreated);
+            }
+        }
+
+        #region testing instrumentation
+
+        private class DataLayerConstructorFixcure : Data.DataAbstractAPI
+        {
+            public override void Dispose()
+            { }
+
+            public override void Start(int numberOfBalls, Action<IVector, Data.IBall> upperLayerHandler)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class DataLayerDisposeFixcure : Data.DataAbstractAPI
+        {
+            internal bool Disposed = false;
+
+            public override void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public override void Start(int numberOfBalls, Action<IVector, Data.IBall> upperLayerHandler)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class DataLayerStartFixcure : Data.DataAbstractAPI
+        {
+            internal bool StartCalled = false;
+            internal int NumberOfBallseCreated = -1;
+
+            public override void Dispose()
+            { }
+
+            public override void Start(int numberOfBalls, Action<IVector, Data.IBall> upperLayerHandler)
+            {
+                StartCalled = true;
+                NumberOfBallseCreated = numberOfBalls;
+                upperLayerHandler(new DataVectorFixture(), new DataBallFixture());
+            }
+
+            private record DataVectorFixture : Data.IVector
+            {
+                public double x { get; init; }
+                public double y { get; init; }
+            }
+
+            private class DataBallFixture : Data.IBall
+            {
+                public event EventHandler<Data.IVector>? NewPositionNotification;
+                public Data.IVector Velocity { get; set; } = new DataVectorFixture();
+                public double Diameter { get; } = 30.0;
+                public double Mass { get; } = 1.0;
+                public Data.IVector Position { get; } = new DataVectorFixture();
+
+                public void UpdatePosition(Data.IVector newPosition)
+                {
+                    NewPositionNotification?.Invoke(this, newPosition);
+                }
+
+                public void UpdateVelocity(Data.IVector newVelocity)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        #endregion testing instrumentation
+    }
 }

--- a/DataTest/BallUnitTest.cs
+++ b/DataTest/BallUnitTest.cs
@@ -7,7 +7,7 @@
     public void ConstructorTestMethod()
     {
       Vector testingVector = new Vector(0.0, 0.0);
-      Ball newInstance = new(testingVector, testingVector);
+      Ball newInstance = new(testingVector, testingVector, 10, 10);
       Assert.IsNotNull(newInstance);
       Assert.IsNotNull(testingVector);
     }
@@ -16,7 +16,7 @@
     public void MoveTestMethod()
     {
       Vector initialPosition = new(10.0, 10.0);
-      Ball newInstance = new(initialPosition, new Vector(0.0, 0.0));
+      Ball newInstance = new(initialPosition, new Vector(0.0, 0.0), 10, 10);
       IVector curentPosition = new Vector(0.0, 0.0);
       int numberOfCallBackCalled = 0;
       newInstance.NewPositionNotification += (sender, position) => { Assert.IsNotNull(sender); curentPosition = position; numberOfCallBackCalled++; };


### PR DESCRIPTION
W pliku BusinessBallUnitTest.cs:
- Poprawiono formatowanie i układ klas/metod testowych.
- Dodano metodę UpdatePosition w DataBallFixture.
- Zmieniono metodę Move, aby wywoływała NewPositionNotification.
- Uporządkowano regiony #region testing instrumentation.

W pliku BusinessLogicUnitTest.cs:
- Poprawiono formatowanie i układ klas/metod testowych.
- Dodano metodę UpdatePosition w DataBallFixture.
- Zmieniono metodę Start w DataLayerStartFixcure, aby poprawnie wywoływała upperLayerHandler.
- Uporządkowano regiony #region testing instrumentation.

W pliku BallUnitTest.cs:
- Zaktualizowano wywołania konstruktora klasy Ball, dodając nowe parametry.
- Dostosowano testy do zmian w konstruktorze klasy Ball.

Zmiany poprawiają czytelność kodu, spójność testów i ich zgodność z aktualną implementacją kodu produkcyjnego.